### PR TITLE
增加图片缩放滑条宽度，提升缩放操作体验

### DIFF
--- a/src/main/kotlin/ink/meodinger/lpfx/component/common/CTextSlider.kt
+++ b/src/main/kotlin/ink/meodinger/lpfx/component/common/CTextSlider.kt
@@ -75,6 +75,8 @@ class CTextSlider : HBox() {
     var scale: Double by scaleProperty
 
     init {
+        // Keep the scale control easy to adjust; JavaFX's default slider width is too short.
+        slider.prefWidth = 200.0
         label.textProperty().bind(scaleProperty.transform { "${(it * 100).roundToInt()}%" })
 
         alignment = Pos.CENTER_LEFT


### PR DESCRIPTION
## 变更说明

将图片缩放控件的滑条首选宽度从 JavaFX 默认值调整为 200px，约为原来的两倍。

## 改动内容

- 增大图片缩放滑条的显示长度
- 保持原有 10%～400% 的缩放范围不变
- 保持现有缩放逻辑和交互方式不变

## 验证

- Maven 构建成功
- 16 个测试全部通过
- 已生成 macOS Apple Silicon 版本应用包进行试用